### PR TITLE
Add 🦄 Shades of Purple Theme + Scripts + Docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "jest": "^23.5.0",
     "lint-staged": "^7.2.2",
     "npm-run-all": "^4.1.3",
+    "prettier": "^1.14.2",
     "prismjs": "^1.15.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/themes/shadesOfPurple.js
+++ b/themes/shadesOfPurple.js
@@ -1,0 +1,99 @@
+// @flow
+// Shades of Purple
+// Author: Ahmad Awais https://twitter.com/MrAhmadAwais
+// Original: https://github.com/ahmadawais/shades-of-purple-vscode/
+// Converted automatically using ./tools/themeFromVsCode and then customized manually.
+
+/*:: import type { PrismTheme } from '../src/types' */
+
+var theme /*: PrismTheme */ = {
+  plain: {
+    color: "#9EFEFF",
+    backgroundColor: "#2D2A55"
+  },
+  styles: [
+    {
+      types: ["changed"],
+      style: {
+        color: "rgb(255, 238, 128)"
+      }
+    },
+    {
+      types: ["deleted"],
+      style: {
+        color: "rgba(239, 83, 80, 0.56)"
+      }
+    },
+    {
+      types: ["inserted"],
+      style: {
+        color: "rgb(173, 219, 103)"
+      }
+    },
+    {
+      types: ["comment"],
+      style: {
+        color: "rgb(179, 98, 255)",
+        fontStyle: "italic"
+      }
+    },
+    {
+      types: ["punctuation"],
+      style: {
+        color: "rgb(255, 255, 255)"
+      }
+    },
+    {
+      types: ["constant"],
+      style: {
+        color: "rgb(255, 98, 140)"
+      }
+    },
+    {
+      types: ["string", "url"],
+      style: {
+        color: "rgb(165, 255, 144)"
+      }
+    },
+    {
+      types: ["variable"],
+      style: {
+        color: "rgb(255, 238, 128)"
+      }
+    },
+    {
+      types: ["number", "boolean"],
+      style: {
+        color: "rgb(255, 98, 140)"
+      }
+    },
+    {
+      types: ["attr-name"],
+      style: {
+        color: "rgb(255, 180, 84)"
+      }
+    },
+    {
+      types: [
+        "keyword",
+        "operator",
+        "property",
+        "namespace",
+        "tag",
+        "selector",
+        "doctype"
+      ],
+      style: {
+        color: "rgb(255, 157, 0)"
+      }
+    },
+    {
+      types: ["builtin", "char", "constant", "function", "class-name"],
+      style: {
+        color: "rgb(250, 208, 0)"
+      }
+    }
+  ]
+};
+
+module.exports = theme;

--- a/tools/themeFromVsCode/README.md
+++ b/tools/themeFromVsCode/README.md
@@ -1,0 +1,5 @@
+# Generate a Prism Theme from VSCode `.json` Themes
+
+1. Open this directory and run `npm install`
+2. Save your VSCode theme in a file called `theme.json` (inside root same as the `README.md` file)
+3. Run `npm start` and your theme will be created in a file called `outputTheme.js` (inside root same as the `README.md` file)

--- a/tools/themeFromVsCode/package.json
+++ b/tools/themeFromVsCode/package.json
@@ -7,5 +7,8 @@
   "dependencies": {
     "color": "^3.0.0",
     "is-equal": "^1.5.5"
+  },
+  "scripts": {
+    "start": "node ./src/index.js"
   }
 }


### PR DESCRIPTION
With this PR I intend to add my VSCode theme 🦄 [Shades of Purple](https://marketplace.visualstudio.com/items?itemName=ahmadawais.shades-of-purple) to prism-react-render.

- [x] 🦄 NEW: Shades of Purple Theme for Prism

I converted the theme and manually edited it to make sure it looks good. Here's [demo of how it looks](https://codesandbox.io/s/2x39ky20my):
![image](https://on.ahmda.ws/a43e02f862f8/c)

- [x] 🐛 FIX: Prettier devDependency required to Commit with Husky

Since there is no contribution guide I had to figure things out on the go and found out that Husky need prettier which was not installed/required as a devDependency in the project. Assumption of having it installed globally is a bit much IMO. So, I added it in there.

- [x] 📖 DOC: Generate a Prism Theme from VSCode

I also wrote basic documentation for someone looking to generate a theme like I did. Thanks for working out the prism theme generator.

- [x] 👌 IMPROVE: Start npm script for theme generation

Added an npm script to easily run the theme generator.

Looking forward, peace! ✌️