### PR TITLE
Fix normalizeTokens overriding "plain" cascading types

### DIFF
--- a/src/components/__tests__/__snapshots__/Highlight.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Highlight.test.js.snap
@@ -252,18 +252,20 @@ exports[`<Highlight /> snapshots renders correctly 1`] = `
          
       </span>
       <span
-        class="token tag tag punctuation"
+        class="token tag punctuation"
         style="color: rgb(108, 103, 131);"
       >
         &lt;
       </span>
       <span
-        class="token plain"
+        class="token tag"
+        style="color: rgb(224, 145, 66);"
       >
         App
       </span>
       <span
-        class="token plain"
+        class="token tag"
+        style="color: rgb(224, 145, 66);"
       >
          
       </span>

--- a/src/utils/__tests__/normalizeTokens.test.js
+++ b/src/utils/__tests__/normalizeTokens.test.js
@@ -64,7 +64,7 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [
         { types: ["test1", "nest"], content: "he" },
-        { types: ["plain"], content: "llo" },
+        { types: ["test1"], content: "llo" },
         { types: ["test2"], content: "world" },
         { types: ["plain"], content: "!" }
       ]
@@ -157,10 +157,10 @@ describe("normalizeTokens", () => {
       [{ types: ["test1", "nest"], content: "h" }],
       [
         { types: ["test1", "nest"], content: "e" },
-        { types: ["plain"], content: "l" }
+        { types: ["test1"], content: "l" }
       ],
       [
-        { types: ["plain"], content: "lo" },
+        { types: ["test1"], content: "lo" },
         { types: ["plain"], content: "world" }
       ],
       [{ types: ["plain"], content: "!" }]

--- a/src/utils/normalizeTokens.js
+++ b/src/utils/normalizeTokens.js
@@ -46,10 +46,10 @@ const normalizeTokens = (tokens: Array<PrismToken | string>): Token[][] => {
 
       // Determine content and append type to types if necessary
       if (typeof token === "string") {
-        types = ["plain"];
+        types = stackIndex > 0 ? types : ["plain"];
         content = token;
       } else {
-        types = types.concat(token.type);
+        types = types[0] === token.type ? types : types.concat(token.type);
         content = token.content;
       }
 


### PR DESCRIPTION
Fix #9 

Previously the assumption was made that nested "plain"
string tokens inside other typed tokens should still
*only* be of type "plain". Instead they should cascade
their styles.

So when the nested types array is: ["tag", "punctuation"],
and we encounter a plain string, the output type should be
the same types array.