### PR TITLE
Remove constructor function from themeDict prototype

### DIFF
--- a/src/components/__tests__/Highlight.test.js
+++ b/src/components/__tests__/Highlight.test.js
@@ -148,5 +148,22 @@ describe("<Highlight />", () => {
         </Highlight>
       );
     });
+
+    it("transforms constructor token style correctly", () => {
+      // From https://github.com/FormidableLabs/prism-react-renderer/issues/11
+      render(
+        <Highlight {...defaultProps} code={"open Common;"} language="reason">
+          {({ tokens, getTokenProps }) => {
+            const line = tokens[0];
+            const token = line[2];
+            const output = getTokenProps({ token, key: 2 });
+
+            expect(typeof output.style).not.toBe("function");
+
+            return null;
+          }}
+        </Highlight>
+      );
+    });
   });
 });

--- a/src/utils/themeToDict.js
+++ b/src/utils/themeToDict.js
@@ -25,7 +25,7 @@ const themeToDict = (theme: PrismTheme, language: Language): ThemeDict => {
     });
 
     return acc;
-  }, {});
+  }, Object.create(null));
 
   // $FlowFixMe
   themeDict.root = (plain: StyleObj);


### PR DESCRIPTION
Fix #11 

The problem was the token that had the type "constructor", so the themeDict returned the `constructor` from the Object prototype.

But don't merge this yet, Flow complains that `Object.create(null)` is not a valid `ThemeDict`. I don't know how to fix that (never used Flow).