### PR TITLE
add maintenance status note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Maintenance Status][maintenance-image]](#maintenance-status)
+
+
 <h1 align="center">
   prism-react-renderer 🖌️
   <br>
@@ -6,10 +9,6 @@
   A lean <a href="https://github.com/PrismJS/prism">Prism</a> highlighter component for React<br>
   Comes with everything to render Prismjs highlighted code directly to React (Native) elements, global-pollution-free!
 </p>
-
-### Maintenance Status: Active
-
-Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
 
 ## Why?
 
@@ -359,3 +358,10 @@ import Prism from "prism-react-renderer/prism";
 ## LICENSE
 
 MIT
+
+## Maintenance Status
+
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+
+[maintenance-image]: https://img.shields.io/badge/maintenance-active-green.svg
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
   Comes with everything to render Prismjs highlighted code directly to React (Native) elements, global-pollution-free!
 </p>
 
+### Maintenance Status: Active
+
+Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+
 ## Why?
 
 Maybe you need to render some extra UI with your Prismjs-highlighted code,


### PR DESCRIPTION
@kitten @sofiapoh We're adding maintenance status to all our OSS. I think this project should be listed as "Active" because of its association with `react-live`, but it might also be listed as "Stable" if you think that's more appropriate. If so, please replace the note I added with:

```
## Maintenance Status

**Stable:** Formidable is not planning to develop any new features for this project. We are still responding to bug reports and security concerns. We are still welcoming PRs for this project, but PRs that include new features should be small and easy to integrate and should not include breaking changes.
```

And change the badge to:

```
[maintenance-image]: https://img.shields.io/badge/maintenance-stable-blue.svg
```