### PR TITLE
Add github theme to the List of available themes

### DIFF
--- a/themes/github.js
+++ b/themes/github.js
@@ -6,9 +6,7 @@
 var theme /*: PrismTheme */ = {
   plain: {
     color: "#393A34",
-    backgroundColor: "#f6f8fa",
-    fontFamily:
-      "SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace"
+    backgroundColor: "#f6f8fa"
   },
   styles: [
     {

--- a/themes/github.js
+++ b/themes/github.js
@@ -1,0 +1,83 @@
+// @flow
+// Original: https://raw.githubusercontent.com/PrismJS/prism-themes/master/themes/prism-ghcolors.css
+
+/*:: import type { PrismTheme } from '../src/types' */
+
+var theme /*: PrismTheme */ = {
+  plain: {
+    color: "#393A34",
+    backgroundColor: "#f6f8fa",
+    fontFamily:
+      "SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace"
+  },
+  styles: [
+    {
+      types: ["comment", "prolog", "doctype", "cdata"],
+      style: {
+        color: "#999988",
+        fontStyle: "italic"
+      }
+    },
+    {
+      types: ["namespace"],
+      style: {
+        opacity: 0.7
+      }
+    },
+    {
+      types: ["string", "attr-value"],
+      style: {
+        color: "#e3116c"
+      }
+    },
+    {
+      types: ["punctuation", "operator"],
+      style: {
+        color: "#393A34"
+      }
+    },
+    {
+      types: [
+        "entity",
+        "url",
+        "symbol",
+        "number",
+        "boolean",
+        "variable",
+        "constant",
+        "property",
+        "regex",
+        "inserted"
+      ],
+      style: {
+        color: "#36acaa"
+      }
+    },
+    {
+      types: ["atrule", "keyword", "attr-name", "selector"],
+      style: {
+        color: "#00a4db"
+      }
+    },
+    {
+      types: ["function", "deleted", "tag"],
+      style: {
+        color: "#d73a49"
+      }
+    },
+    {
+      types: ["function-variable"],
+      style: {
+        color: "#6f42c1"
+      }
+    },
+    {
+      types: ["tag", "selector", "keyword"],
+      style: {
+        color: "#00009f"
+      }
+    }
+  ]
+};
+
+module.exports = theme;


### PR DESCRIPTION
### WHAT
This PR add the github theme to list of themes present. The colors were originally taken from [here](https://raw.githubusercontent.com/zeit/docs/dc85902cecbe0e24f8ff52bb8f6e12045e107ed6/pages/docs/api/v1/api-docs-mdx/errors/domains.mdx). Although i had to make some modifications to fonts to make it look better.

Fixes issue https://github.com/FormidableLabs/prism-react-renderer/issues/32

Demo
<img width="708" alt="Screen Shot 2019-04-24 at 3 04 37 AM" src="https://user-images.githubusercontent.com/13037986/56630661-bffde000-666f-11e9-9b6e-d766000ddc83.png">
