### PR TITLE
feat: add tsx support

### DIFF
--- a/src/vendor/prism/includeLangs.js
+++ b/src/vendor/prism/includeLangs.js
@@ -32,6 +32,7 @@ module.exports = {
   scss: true,
   sql: true,
   stylus: true,
+  tsx: true,
   typescript: true,
   wasm: true,
   yaml: true


### PR DESCRIPTION
Adds `tsx` to include langs. 

Currently using `tsx` with `react-live` and can't get syntax highlighting.