### PR TITLE
Update package.json so NPM shows link to GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.js",
   "types": "index.d.ts",
   "license": "MIT",
-  "repository": "git@github.com:FormidableLabs/prism-react-renderer.git",
+  "repository": "https://github.com/FormidableLabs/prism-react-renderer",
   "files": [
     "index.d.ts",
     "dist",


### PR DESCRIPTION
Your [npm page](https://www.npmjs.com/package/prism-react-renderer) doesn't have a link to this repo; so this will add one!