### PR TITLE
fix: don't override undefined style and key props

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -51,14 +51,12 @@ class Highlight extends Component<Props, *> {
     key,
     className,
     style,
-    line,
+    line, 
     ...rest
   }: LineInputProps): LineOutputProps => {
     const output: LineOutputProps = {
       ...rest,
       className: "token-line",
-      style: undefined,
-      key: undefined
     };
 
     const themeDict = this.getThemeDict(this.props);

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -56,7 +56,7 @@ class Highlight extends Component<Props, *> {
   }: LineInputProps): LineOutputProps => {
     const output: LineOutputProps = {
       ...rest,
-      className: "token-line",
+      className: "token-line"
     };
 
     const themeDict = this.getThemeDict(this.props);
@@ -104,8 +104,7 @@ class Highlight extends Component<Props, *> {
       ...rest,
       className: `token ${token.types.join(" ")}`,
       children: token.content,
-      style: this.getStyleForToken(token),
-      key: undefined
+      style: this.getStyleForToken(token)
     };
 
     if (style !== undefined) {


### PR DESCRIPTION
the code looks like it's trying to not override any user defined key or style added outside the getLineProps function, but in practice it's overriding them to `undefined` Object.assign doesn't ignore explicit `undefined` keys