### PR TITLE
feat: Add support for Java and Ruby

### DIFF
--- a/src/vendor/prism/includeLangs.js
+++ b/src/vendor/prism/includeLangs.js
@@ -28,6 +28,7 @@ module.exports = {
   ocaml: true,
   python: true,
   reason: true,
+  ruby: true,
   sass: true,
   scss: true,
   sql: true,

--- a/src/vendor/prism/includeLangs.js
+++ b/src/vendor/prism/includeLangs.js
@@ -20,6 +20,7 @@ module.exports = {
   go: true,
   graphql: true,
   handlebars: true,
+  java: true,
   json: true,
   less: true,
   makefile: true,


### PR DESCRIPTION
Ruby and Java are currently the 6th and 3rd most used languages in the world respectively, ahead of C, PHP, Shell, etc. Seems reasonable to include them here. 