### PR TITLE
Preserve newlines on copy + paste

### DIFF
--- a/src/components/__tests__/__snapshots__/Highlight.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Highlight.test.js.snap
@@ -203,7 +203,10 @@ exports[`<Highlight /> snapshots renders correctly 1`] = `
       <span
         class="token plain"
         style="display: inline-block;"
-      />
+      >
+        
+
+      </span>
     </div>
     <div
       class="token-line"
@@ -339,7 +342,10 @@ exports[`<Highlight /> snapshots renders unsupported languages correctly 1`] = `
       <span
         class="token plain"
         style="display: inline-block;"
-      />
+      >
+        
+
+      </span>
     </div>
     <div
       class="token-line"

--- a/src/utils/__tests__/normalizeTokens.test.js
+++ b/src/utils/__tests__/normalizeTokens.test.js
@@ -8,23 +8,23 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [
         { types: ["plain"], content: "hello" },
-        { types: ["plain"], content: "world" },
-      ],
+        { types: ["plain"], content: "world" }
+      ]
     ]);
   });
 
   it("handles flat tokens", () => {
     const input = [
       { type: "test1", content: "hello" },
-      { type: "test2", content: "world" },
+      { type: "test2", content: "world" }
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1"], content: "hello" },
-        { types: ["test2"], content: "world" },
-      ],
+        { types: ["test2"], content: "world" }
+      ]
     ]);
   });
 
@@ -34,10 +34,10 @@ describe("normalizeTokens", () => {
         type: "test1",
         content: [
           { type: "nest1", content: "he" },
-          { type: "nest2", content: "llo" },
-        ],
+          { type: "nest2", content: "llo" }
+        ]
       },
-      { type: "test2", content: "world" },
+      { type: "test2", content: "world" }
     ];
     const output = normalizeTokens(input);
 
@@ -45,8 +45,8 @@ describe("normalizeTokens", () => {
       [
         { types: ["test1", "nest1"], content: "he" },
         { types: ["test1", "nest2"], content: "llo" },
-        { types: ["test2"], content: "world" },
-      ],
+        { types: ["test2"], content: "world" }
+      ]
     ]);
   });
 
@@ -54,10 +54,10 @@ describe("normalizeTokens", () => {
     const input = [
       {
         type: "test1",
-        content: [{ type: "nest", content: "he" }, "llo"],
+        content: [{ type: "nest", content: "he" }, "llo"]
       },
       { type: "test2", content: "world" },
-      "!",
+      "!"
     ];
     const output = normalizeTokens(input);
 
@@ -66,8 +66,8 @@ describe("normalizeTokens", () => {
         { types: ["test1", "nest"], content: "he" },
         { types: ["test1"], content: "llo" },
         { types: ["test2"], content: "world" },
-        { types: ["plain"], content: "!" },
-      ],
+        { types: ["plain"], content: "!" }
+      ]
     ]);
   });
 
@@ -78,10 +78,10 @@ describe("normalizeTokens", () => {
         content: [
           {
             type: "2",
-            content: [{ type: "3", content: "hello" }],
-          },
-        ],
-      },
+            content: [{ type: "3", content: "hello" }]
+          }
+        ]
+      }
     ];
     const output = normalizeTokens(input);
 
@@ -95,25 +95,25 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [
         { types: ["plain"], content: "hello" },
-        { types: ["plain"], content: " " },
+        { types: ["plain"], content: " " }
       ],
-      [{ types: ["plain"], content: "world" }],
+      [{ types: ["plain"], content: "world" }]
     ]);
   });
 
   it("handles flat tokens with newlines", () => {
     const input = [
       { type: "test1", content: "hello" },
-      { type: "test2", content: "wor\nld" },
+      { type: "test2", content: "wor\nld" }
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1"], content: "hello" },
-        { types: ["test2"], content: "wor" },
+        { types: ["test2"], content: "wor" }
       ],
-      [{ types: ["test2"], content: "ld" }],
+      [{ types: ["test2"], content: "ld" }]
     ]);
   });
 
@@ -123,23 +123,23 @@ describe("normalizeTokens", () => {
         type: "test1",
         content: [
           { type: "nest1", content: "he" },
-          { type: "nest2", content: "l\nlo" },
-        ],
+          { type: "nest2", content: "l\nlo" }
+        ]
       },
-      { type: "test2", content: "wor\nld" },
+      { type: "test2", content: "wor\nld" }
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1", "nest1"], content: "he" },
-        { types: ["test1", "nest2"], content: "l" },
+        { types: ["test1", "nest2"], content: "l" }
       ],
       [
         { types: ["test1", "nest2"], content: "lo" },
-        { types: ["test2"], content: "wor" },
+        { types: ["test2"], content: "wor" }
       ],
-      [{ types: ["test2"], content: "ld" }],
+      [{ types: ["test2"], content: "ld" }]
     ]);
   });
 
@@ -147,9 +147,9 @@ describe("normalizeTokens", () => {
     const input = [
       {
         type: "test1",
-        content: [{ type: "nest", content: "h\ne" }, "l\nlo"],
+        content: [{ type: "nest", content: "h\ne" }, "l\nlo"]
       },
-      "world\n!",
+      "world\n!"
     ];
     const output = normalizeTokens(input);
 
@@ -157,13 +157,13 @@ describe("normalizeTokens", () => {
       [{ types: ["test1", "nest"], content: "h" }],
       [
         { types: ["test1", "nest"], content: "e" },
-        { types: ["test1"], content: "l" },
+        { types: ["test1"], content: "l" }
       ],
       [
         { types: ["test1"], content: "lo" },
-        { types: ["plain"], content: "world" },
+        { types: ["plain"], content: "world" }
       ],
-      [{ types: ["plain"], content: "!" }],
+      [{ types: ["plain"], content: "!" }]
     ]);
   });
 
@@ -174,16 +174,16 @@ describe("normalizeTokens", () => {
         content: [
           {
             type: "2",
-            content: [{ type: "3", content: "hel\nlo" }],
-          },
-        ],
-      },
+            content: [{ type: "3", content: "hel\nlo" }]
+          }
+        ]
+      }
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [{ types: ["1", "2", "3"], content: "hel" }],
-      [{ types: ["1", "2", "3"], content: "lo" }],
+      [{ types: ["1", "2", "3"], content: "lo" }]
     ]);
   });
 
@@ -194,7 +194,7 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [{ types: ["plain"], content: "\n", empty: true }],
       [{ types: ["plain"], content: "\n", empty: true }],
-      [{ types: ["plain"], content: "\n", empty: true }],
+      [{ types: ["plain"], content: "\n", empty: true }]
     ]);
   });
 });

--- a/src/utils/__tests__/normalizeTokens.test.js
+++ b/src/utils/__tests__/normalizeTokens.test.js
@@ -8,23 +8,23 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [
         { types: ["plain"], content: "hello" },
-        { types: ["plain"], content: "world" }
-      ]
+        { types: ["plain"], content: "world" },
+      ],
     ]);
   });
 
   it("handles flat tokens", () => {
     const input = [
       { type: "test1", content: "hello" },
-      { type: "test2", content: "world" }
+      { type: "test2", content: "world" },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1"], content: "hello" },
-        { types: ["test2"], content: "world" }
-      ]
+        { types: ["test2"], content: "world" },
+      ],
     ]);
   });
 
@@ -34,10 +34,10 @@ describe("normalizeTokens", () => {
         type: "test1",
         content: [
           { type: "nest1", content: "he" },
-          { type: "nest2", content: "llo" }
-        ]
+          { type: "nest2", content: "llo" },
+        ],
       },
-      { type: "test2", content: "world" }
+      { type: "test2", content: "world" },
     ];
     const output = normalizeTokens(input);
 
@@ -45,8 +45,8 @@ describe("normalizeTokens", () => {
       [
         { types: ["test1", "nest1"], content: "he" },
         { types: ["test1", "nest2"], content: "llo" },
-        { types: ["test2"], content: "world" }
-      ]
+        { types: ["test2"], content: "world" },
+      ],
     ]);
   });
 
@@ -54,10 +54,10 @@ describe("normalizeTokens", () => {
     const input = [
       {
         type: "test1",
-        content: [{ type: "nest", content: "he" }, "llo"]
+        content: [{ type: "nest", content: "he" }, "llo"],
       },
       { type: "test2", content: "world" },
-      "!"
+      "!",
     ];
     const output = normalizeTokens(input);
 
@@ -66,8 +66,8 @@ describe("normalizeTokens", () => {
         { types: ["test1", "nest"], content: "he" },
         { types: ["test1"], content: "llo" },
         { types: ["test2"], content: "world" },
-        { types: ["plain"], content: "!" }
-      ]
+        { types: ["plain"], content: "!" },
+      ],
     ]);
   });
 
@@ -78,10 +78,10 @@ describe("normalizeTokens", () => {
         content: [
           {
             type: "2",
-            content: [{ type: "3", content: "hello" }]
-          }
-        ]
-      }
+            content: [{ type: "3", content: "hello" }],
+          },
+        ],
+      },
     ];
     const output = normalizeTokens(input);
 
@@ -95,25 +95,25 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [
         { types: ["plain"], content: "hello" },
-        { types: ["plain"], content: " " }
+        { types: ["plain"], content: " " },
       ],
-      [{ types: ["plain"], content: "world" }]
+      [{ types: ["plain"], content: "world" }],
     ]);
   });
 
   it("handles flat tokens with newlines", () => {
     const input = [
       { type: "test1", content: "hello" },
-      { type: "test2", content: "wor\nld" }
+      { type: "test2", content: "wor\nld" },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1"], content: "hello" },
-        { types: ["test2"], content: "wor" }
+        { types: ["test2"], content: "wor" },
       ],
-      [{ types: ["test2"], content: "ld" }]
+      [{ types: ["test2"], content: "ld" }],
     ]);
   });
 
@@ -123,23 +123,23 @@ describe("normalizeTokens", () => {
         type: "test1",
         content: [
           { type: "nest1", content: "he" },
-          { type: "nest2", content: "l\nlo" }
-        ]
+          { type: "nest2", content: "l\nlo" },
+        ],
       },
-      { type: "test2", content: "wor\nld" }
+      { type: "test2", content: "wor\nld" },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1", "nest1"], content: "he" },
-        { types: ["test1", "nest2"], content: "l" }
+        { types: ["test1", "nest2"], content: "l" },
       ],
       [
         { types: ["test1", "nest2"], content: "lo" },
-        { types: ["test2"], content: "wor" }
+        { types: ["test2"], content: "wor" },
       ],
-      [{ types: ["test2"], content: "ld" }]
+      [{ types: ["test2"], content: "ld" }],
     ]);
   });
 
@@ -147,9 +147,9 @@ describe("normalizeTokens", () => {
     const input = [
       {
         type: "test1",
-        content: [{ type: "nest", content: "h\ne" }, "l\nlo"]
+        content: [{ type: "nest", content: "h\ne" }, "l\nlo"],
       },
-      "world\n!"
+      "world\n!",
     ];
     const output = normalizeTokens(input);
 
@@ -157,13 +157,13 @@ describe("normalizeTokens", () => {
       [{ types: ["test1", "nest"], content: "h" }],
       [
         { types: ["test1", "nest"], content: "e" },
-        { types: ["test1"], content: "l" }
+        { types: ["test1"], content: "l" },
       ],
       [
         { types: ["test1"], content: "lo" },
-        { types: ["plain"], content: "world" }
+        { types: ["plain"], content: "world" },
       ],
-      [{ types: ["plain"], content: "!" }]
+      [{ types: ["plain"], content: "!" }],
     ]);
   });
 
@@ -174,16 +174,16 @@ describe("normalizeTokens", () => {
         content: [
           {
             type: "2",
-            content: [{ type: "3", content: "hel\nlo" }]
-          }
-        ]
-      }
+            content: [{ type: "3", content: "hel\nlo" }],
+          },
+        ],
+      },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [{ types: ["1", "2", "3"], content: "hel" }],
-      [{ types: ["1", "2", "3"], content: "lo" }]
+      [{ types: ["1", "2", "3"], content: "lo" }],
     ]);
   });
 
@@ -192,9 +192,9 @@ describe("normalizeTokens", () => {
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
-      [{ types: ["plain"], content: "", empty: true }],
-      [{ types: ["plain"], content: "", empty: true }],
-      [{ types: ["plain"], content: "", empty: true }]
+      [{ types: ["plain"], content: "\n", empty: true }],
+      [{ types: ["plain"], content: "\n", empty: true }],
+      [{ types: ["plain"], content: "\n", empty: true }],
     ]);
   });
 });

--- a/src/utils/normalizeTokens.js
+++ b/src/utils/normalizeTokens.js
@@ -10,7 +10,7 @@ const normalizeEmptyLines = (line: Token[]) => {
     line.push({
       types: ["plain"],
       content: "\n",
-      empty: true,
+      empty: true
     });
   } else if (line.length === 1 && line[0].content === "") {
     line[0].content = "\n";

--- a/src/utils/normalizeTokens.js
+++ b/src/utils/normalizeTokens.js
@@ -9,19 +9,17 @@ const normalizeEmptyLines = (line: Token[]) => {
   if (line.length === 0) {
     line.push({
       types: ["plain"],
-      content: "",
-      empty: true
+      content: "\n",
+      empty: true,
     });
   } else if (line.length === 1 && line[0].content === "") {
+    line[0].content = "\n";
     line[0].empty = true;
   }
 };
 
-const appendTypes = (
-  types: string[],
-  add: string[] | string
-): string[] => {
-  const typesSize = types.length
+const appendTypes = (types: string[], add: string[] | string): string[] => {
+  const typesSize = types.length;
   if (typesSize > 0 && types[typesSize - 1] === add) {
     return types;
   }


### PR DESCRIPTION
Adresses #78 

Currently when copy + pasting, empty lines are not preserved in the output, which could be unexpected for the user.

## Changes

Adding a newline `\n` as the content for empty rows seems to help preserve newlines when copy + pasting; without adding any additional characters (e.g. whitespace) or changing the visuals.

I've tested this on macOS & windows, but haven't been able to test on a linux device

## Tests
### Local:
[x] macOS
[x] Windows
[ ] Unix

### Unit tests:
- Updated to expect `\n` as content for empty lines

### Snapshots:
- Updated as empty line spans are no-longer self-closing
<img src="https://user-images.githubusercontent.com/21317379/82727058-f200cc00-9cdf-11ea-95e9-b76e48425e1f.png" width="400px" />

## Examples
I shimmed this functionality into the codesandbox example, so it can be tested:
https://codesandbox.io/s/prism-react-renderer-example-r8dl3

> note - the line numbers example seems to paste with extra newlines even in the original example, so I don't think there's a regression there

### Pasted from examples:
**Current**
```js
(function someDemo() {
  var test = "Hello World!";
  console.log(test);
})();
return () => <App />;
```

**Updated**
```js
(function someDemo() {
  var test = "Hello World!";
  console.log(test);
})();

return () => <App />;
```