### PR TITLE
Call prism `before-tokenize` and `after-tokenize` hooks

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -12,8 +12,10 @@ import type {
   TokenInputProps,
   TokenOutputProps,
   RenderProps,
+  PrismGrammar,
   PrismLib,
   PrismTheme,
+  PrismToken,
 } from "../types";
 
 type Props = {
@@ -121,6 +123,25 @@ class Highlight extends Component<Props, *> {
     return output;
   };
 
+  tokenize = (
+    Prism: PrismLib,
+    code: string,
+    grammar: PrismGrammar,
+    language: Language
+  ): Array<PrismToken> => {
+    const env = {
+      code,
+      grammar,
+      language,
+    };
+
+    Prism.hooks.run("before-tokenize", env);
+    env.tokens = Prism.tokenize(env.code, env.grammar, env.language);
+    Prism.hooks.run("after-tokenize", env);
+
+    return env.tokens;
+  };
+
   render() {
     const { Prism, language, code, children } = this.props;
 
@@ -128,7 +149,9 @@ class Highlight extends Component<Props, *> {
 
     const grammar = Prism.languages[language];
     const mixedTokens =
-      grammar !== undefined ? Prism.tokenize(code, grammar, language) : [code];
+      grammar !== undefined
+        ? this.tokenize(Prism, code, grammar, language)
+        : [code];
     const tokens = normalizeTokens(mixedTokens);
 
     return children({

--- a/src/types.js
+++ b/src/types.js
@@ -5,7 +5,7 @@ import includedLangs from "./vendor/prism/includeLangs";
 
 export type Language = $Keys<typeof includedLangs>;
 
-type PrismGrammar = {
+export type PrismGrammar = {
   [key: string]: mixed,
 };
 
@@ -37,6 +37,12 @@ export type PrismLib = {
     grammar: PrismGrammar,
     language: Language
   ) => string,
+  hooks: {
+    run: (
+      name: string,
+      env: { code: string, grammar: PrismGrammar, language: Language }
+    ) => void,
+  },
 };
 
 export type StyleObj = {

--- a/src/vendor/prism/prism-core.js
+++ b/src/vendor/prism/prism-core.js
@@ -339,6 +339,7 @@ var Prism = (function () {
 
     hooks: {
       add: function () {},
+      run: function (name, env) {},
     },
 
     tokenize: function (text, grammar, language) {


### PR DESCRIPTION
Closes https://github.com/FormidableLabs/prism-react-renderer/issues/104
Based on https://github.com/PrismJS/prism/blob/022f90a0bf8ac7e40373d1b783354715b0a1020f/prism.js#L606-L616

With this change, users with custom languages can also provide a custom version of Prism to make languages such as `ERB` to work with `<Highlight>`
