### PR TITLE
Fix prettier glob to correctly navigate recursively and format missing files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "rollup -c rollup.config.js",
     "test": "jest",
     "flow": "flow check",
-    "format": "prettier --write src/**/*.js",
+    "format": "prettier --write 'src/**/*.js'",
     "prepublishOnly": "run-p flow build"
   },
   "husky": {

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -8,7 +8,7 @@ import type { PrismLib } from "./types";
 const defaultProps = {
   // $FlowFixMe
   Prism: (Prism: PrismLib),
-  theme
+  theme,
 };
 
 export default defaultProps;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,9 @@
 // @flow
 
-import Prism from './vendor/prism'
-import defaultProps from './defaultProps'
-import Highlight from './components/Highlight'
+import Prism from "./vendor/prism";
+import defaultProps from "./defaultProps";
+import Highlight from "./components/Highlight";
 
-export {
-  Prism,
-  defaultProps
-}
+export { Prism, defaultProps };
 
-export default Highlight
+export default Highlight;

--- a/src/types.js
+++ b/src/types.js
@@ -6,23 +6,23 @@ import includedLangs from "./vendor/prism/includeLangs";
 export type Language = $Keys<typeof includedLangs>;
 
 type PrismGrammar = {
-  [key: string]: mixed
+  [key: string]: mixed,
 };
 
 type LanguagesDict = {
-  [lang: Language]: PrismGrammar
+  [lang: Language]: PrismGrammar,
 };
 
 export type PrismToken = {
   type: string | string[],
   alias: string | string[],
-  content: Array<PrismToken | string> | string
+  content: Array<PrismToken | string> | string,
 };
 
 export type Token = {
   types: string[],
   content: string,
-  empty?: boolean
+  empty?: boolean,
 };
 
 export type PrismLib = {
@@ -32,11 +32,15 @@ export type PrismLib = {
     grammar: PrismGrammar,
     language: Language
   ) => Array<PrismToken | string>,
-  highlight: (code: string, grammar: PrismGrammar, language: Language) => string
+  highlight: (
+    code: string,
+    grammar: PrismGrammar,
+    language: Language
+  ) => string,
 };
 
 export type StyleObj = {
-  [key: string]: string | number | null
+  [key: string]: string | number | null,
 };
 
 export type LineInputProps = {
@@ -44,14 +48,14 @@ export type LineInputProps = {
   style?: StyleObj,
   className?: string,
   line: Token[],
-  [key: string]: mixed
+  [key: string]: mixed,
 };
 
 export type LineOutputProps = {
   key?: Key,
   style?: StyleObj,
   className: string,
-  [key: string]: mixed
+  [key: string]: mixed,
 };
 
 export type TokenInputProps = {
@@ -59,7 +63,7 @@ export type TokenInputProps = {
   style?: StyleObj,
   className?: string,
   token: Token,
-  [key: string]: mixed
+  [key: string]: mixed,
 };
 
 export type TokenOutputProps = {
@@ -67,14 +71,14 @@ export type TokenOutputProps = {
   style?: StyleObj,
   className: string,
   children: string,
-  [key: string]: mixed
+  [key: string]: mixed,
 };
 
 export type RenderProps = {
   tokens: Token[][],
   className: string,
   getLineProps: (input: LineInputProps) => LineOutputProps,
-  getTokenProps: (input: TokenInputProps) => TokenOutputProps
+  getTokenProps: (input: TokenInputProps) => TokenOutputProps,
 };
 
 export type PrismThemeEntry = {
@@ -99,7 +103,7 @@ export type PrismThemeEntry = {
     | "line-through"
     | "underline line-through",
   opacity?: number,
-  [styleKey: string]: string | number | void
+  [styleKey: string]: string | number | void,
 };
 
 export type PrismTheme = {
@@ -107,6 +111,6 @@ export type PrismTheme = {
   styles: Array<{
     types: string[],
     style: PrismThemeEntry,
-    languages?: Language[]
-  }>
+    languages?: Language[],
+  }>,
 };

--- a/src/utils/__tests__/normalizeTokens.test.js
+++ b/src/utils/__tests__/normalizeTokens.test.js
@@ -8,23 +8,23 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [
         { types: ["plain"], content: "hello" },
-        { types: ["plain"], content: "world" }
-      ]
+        { types: ["plain"], content: "world" },
+      ],
     ]);
   });
 
   it("handles flat tokens", () => {
     const input = [
       { type: "test1", content: "hello" },
-      { type: "test2", content: "world" }
+      { type: "test2", content: "world" },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1"], content: "hello" },
-        { types: ["test2"], content: "world" }
-      ]
+        { types: ["test2"], content: "world" },
+      ],
     ]);
   });
 
@@ -34,10 +34,10 @@ describe("normalizeTokens", () => {
         type: "test1",
         content: [
           { type: "nest1", content: "he" },
-          { type: "nest2", content: "llo" }
-        ]
+          { type: "nest2", content: "llo" },
+        ],
       },
-      { type: "test2", content: "world" }
+      { type: "test2", content: "world" },
     ];
     const output = normalizeTokens(input);
 
@@ -45,8 +45,8 @@ describe("normalizeTokens", () => {
       [
         { types: ["test1", "nest1"], content: "he" },
         { types: ["test1", "nest2"], content: "llo" },
-        { types: ["test2"], content: "world" }
-      ]
+        { types: ["test2"], content: "world" },
+      ],
     ]);
   });
 
@@ -54,10 +54,10 @@ describe("normalizeTokens", () => {
     const input = [
       {
         type: "test1",
-        content: [{ type: "nest", content: "he" }, "llo"]
+        content: [{ type: "nest", content: "he" }, "llo"],
       },
       { type: "test2", content: "world" },
-      "!"
+      "!",
     ];
     const output = normalizeTokens(input);
 
@@ -66,8 +66,8 @@ describe("normalizeTokens", () => {
         { types: ["test1", "nest"], content: "he" },
         { types: ["test1"], content: "llo" },
         { types: ["test2"], content: "world" },
-        { types: ["plain"], content: "!" }
-      ]
+        { types: ["plain"], content: "!" },
+      ],
     ]);
   });
 
@@ -78,10 +78,10 @@ describe("normalizeTokens", () => {
         content: [
           {
             type: "2",
-            content: [{ type: "3", content: "hello" }]
-          }
-        ]
-      }
+            content: [{ type: "3", content: "hello" }],
+          },
+        ],
+      },
     ];
     const output = normalizeTokens(input);
 
@@ -95,25 +95,25 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [
         { types: ["plain"], content: "hello" },
-        { types: ["plain"], content: " " }
+        { types: ["plain"], content: " " },
       ],
-      [{ types: ["plain"], content: "world" }]
+      [{ types: ["plain"], content: "world" }],
     ]);
   });
 
   it("handles flat tokens with newlines", () => {
     const input = [
       { type: "test1", content: "hello" },
-      { type: "test2", content: "wor\nld" }
+      { type: "test2", content: "wor\nld" },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1"], content: "hello" },
-        { types: ["test2"], content: "wor" }
+        { types: ["test2"], content: "wor" },
       ],
-      [{ types: ["test2"], content: "ld" }]
+      [{ types: ["test2"], content: "ld" }],
     ]);
   });
 
@@ -123,23 +123,23 @@ describe("normalizeTokens", () => {
         type: "test1",
         content: [
           { type: "nest1", content: "he" },
-          { type: "nest2", content: "l\nlo" }
-        ]
+          { type: "nest2", content: "l\nlo" },
+        ],
       },
-      { type: "test2", content: "wor\nld" }
+      { type: "test2", content: "wor\nld" },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [
         { types: ["test1", "nest1"], content: "he" },
-        { types: ["test1", "nest2"], content: "l" }
+        { types: ["test1", "nest2"], content: "l" },
       ],
       [
         { types: ["test1", "nest2"], content: "lo" },
-        { types: ["test2"], content: "wor" }
+        { types: ["test2"], content: "wor" },
       ],
-      [{ types: ["test2"], content: "ld" }]
+      [{ types: ["test2"], content: "ld" }],
     ]);
   });
 
@@ -147,9 +147,9 @@ describe("normalizeTokens", () => {
     const input = [
       {
         type: "test1",
-        content: [{ type: "nest", content: "h\ne" }, "l\nlo"]
+        content: [{ type: "nest", content: "h\ne" }, "l\nlo"],
       },
-      "world\n!"
+      "world\n!",
     ];
     const output = normalizeTokens(input);
 
@@ -157,13 +157,13 @@ describe("normalizeTokens", () => {
       [{ types: ["test1", "nest"], content: "h" }],
       [
         { types: ["test1", "nest"], content: "e" },
-        { types: ["test1"], content: "l" }
+        { types: ["test1"], content: "l" },
       ],
       [
         { types: ["test1"], content: "lo" },
-        { types: ["plain"], content: "world" }
+        { types: ["plain"], content: "world" },
       ],
-      [{ types: ["plain"], content: "!" }]
+      [{ types: ["plain"], content: "!" }],
     ]);
   });
 
@@ -174,16 +174,16 @@ describe("normalizeTokens", () => {
         content: [
           {
             type: "2",
-            content: [{ type: "3", content: "hel\nlo" }]
-          }
-        ]
-      }
+            content: [{ type: "3", content: "hel\nlo" }],
+          },
+        ],
+      },
     ];
     const output = normalizeTokens(input);
 
     expect(output).toEqual([
       [{ types: ["1", "2", "3"], content: "hel" }],
-      [{ types: ["1", "2", "3"], content: "lo" }]
+      [{ types: ["1", "2", "3"], content: "lo" }],
     ]);
   });
 
@@ -194,7 +194,7 @@ describe("normalizeTokens", () => {
     expect(output).toEqual([
       [{ types: ["plain"], content: "\n", empty: true }],
       [{ types: ["plain"], content: "\n", empty: true }],
-      [{ types: ["plain"], content: "\n", empty: true }]
+      [{ types: ["plain"], content: "\n", empty: true }],
     ]);
   });
 });

--- a/src/utils/__tests__/themeToDict.test.js
+++ b/src/utils/__tests__/themeToDict.test.js
@@ -1,4 +1,4 @@
-import themeToDict from "../themeToDict"
+import themeToDict from "../themeToDict";
 
 describe("themeToDict", () => {
   it("converts entry.types to dictionary", () => {
@@ -24,7 +24,7 @@ describe("themeToDict", () => {
           },
         },
       ],
-    }
+    };
 
     const expected = {
       root: {
@@ -43,31 +43,33 @@ describe("themeToDict", () => {
       3: {
         color: "blue",
       },
-    }
+    };
 
-    expect(themeToDict(input)).toEqual(expected)
+    expect(themeToDict(input)).toEqual(expected);
     // Check order in which keys were added to implicitly test merge strategy
-    expect(Object.keys(themeToDict(input, 'js'))).toEqual(Object.keys(expected))
-  })
+    expect(Object.keys(themeToDict(input, "js"))).toEqual(
+      Object.keys(expected)
+    );
+  });
 
   it("limits entries by entry.languages", () => {
     const input = {
       plain: {},
       styles: [
         {
-          types: ['test'],
-          languages: ['js'],
+          types: ["test"],
+          languages: ["js"],
           style: {
             color: "green",
           },
-        }
+        },
       ],
-    }
+    };
 
-    expect(themeToDict(input, 'js').test).toEqual({
-      color: 'green'
-    })
+    expect(themeToDict(input, "js").test).toEqual({
+      color: "green",
+    });
 
-    expect(themeToDict(input, 'ocaml').test).toEqual(undefined)
-  })
-})
+    expect(themeToDict(input, "ocaml").test).toEqual(undefined);
+  });
+});

--- a/src/vendor/prism/includeLangs.js
+++ b/src/vendor/prism/includeLangs.js
@@ -35,5 +35,5 @@ module.exports = {
   tsx: true,
   typescript: true,
   wasm: true,
-  yaml: true
+  yaml: true,
 };

--- a/src/vendor/prism/index.js
+++ b/src/vendor/prism/index.js
@@ -1,5 +1,5 @@
-import Prism from './prism-core'
-import codegen from 'codegen.macro'
+import Prism from "./prism-core";
+import codegen from "codegen.macro";
 
 // Babel Codegen Macro:
 // Get a list of all prismjs languages and inline them here.
@@ -77,6 +77,6 @@ codegen`
   })
 
   module.exports = output
-`
+`;
 
-export default Prism
+export default Prism;

--- a/src/vendor/prism/prism-core.js
+++ b/src/vendor/prism/prism-core.js
@@ -15,14 +15,14 @@
  * It has also been run through prettier
  */
 
-var Prism = (function() {
+var Prism = (function () {
   // Private helper vars
   var lang = /\blang(?:uage)?-([\w-]+)\b/i;
   var uniqueId = 0;
 
   var _ = {
     util: {
-      encode: function(tokens) {
+      encode: function (tokens) {
         if (tokens instanceof Token) {
           return new Token(
             tokens.type,
@@ -39,11 +39,11 @@ var Prism = (function() {
         }
       },
 
-      type: function(o) {
+      type: function (o) {
         return Object.prototype.toString.call(o).match(/\[object (\w+)\]/)[1];
       },
 
-      objId: function(obj) {
+      objId: function (obj) {
         if (!obj["__id"]) {
           Object.defineProperty(obj, "__id", { value: ++uniqueId });
         }
@@ -51,7 +51,7 @@ var Prism = (function() {
       },
 
       // Deep clone a language definition (e.g. to extend it)
-      clone: function(o, visited) {
+      clone: function (o, visited) {
         var type = _.util.type(o);
         visited = visited || {};
 
@@ -78,7 +78,7 @@ var Prism = (function() {
             var clone = [];
             visited[_.util.objId(o)] = clone;
 
-            o.forEach(function(v, i) {
+            o.forEach(function (v, i) {
               clone[i] = _.util.clone(v, visited);
             });
 
@@ -86,11 +86,11 @@ var Prism = (function() {
         }
 
         return o;
-      }
+      },
     },
 
     languages: {
-      extend: function(id, redef) {
+      extend: function (id, redef) {
         var lang = _.util.clone(_.languages[id]);
 
         for (var key in redef) {
@@ -109,7 +109,7 @@ var Prism = (function() {
        * @param insert Object with the key/value pairs to insert
        * @param root The object that contains `inside`. If equal to Prism.languages, it can be omitted.
        */
-      insertBefore: function(inside, before, insert, root) {
+      insertBefore: function (inside, before, insert, root) {
         root = root || _.languages;
         var grammar = root[inside];
 
@@ -142,7 +142,7 @@ var Prism = (function() {
         }
 
         // Update references in other language definitions
-        _.languages.DFS(_.languages, function(key, value) {
+        _.languages.DFS(_.languages, function (key, value) {
           if (value === root[inside] && key != inside) {
             this[key] = ret;
           }
@@ -152,7 +152,7 @@ var Prism = (function() {
       },
 
       // Traverse a language definition with Depth First Search
-      DFS: function(o, callback, type, visited) {
+      DFS: function (o, callback, type, visited) {
         visited = visited || {};
         for (var i in o) {
           if (o.hasOwnProperty(i)) {
@@ -173,22 +173,22 @@ var Prism = (function() {
             }
           }
         }
-      }
+      },
     },
 
     plugins: {},
 
-    highlight: function(text, grammar, language) {
+    highlight: function (text, grammar, language) {
       var env = {
         code: text,
         grammar: grammar,
-        language: language
+        language: language,
       };
       env.tokens = _.tokenize(env.code, env.grammar);
       return Token.stringify(_.util.encode(env.tokens), env.language);
     },
 
-    matchGrammar: function(
+    matchGrammar: function (
       text,
       strarr,
       grammar,
@@ -338,10 +338,10 @@ var Prism = (function() {
     },
 
     hooks: {
-      add: function() {}
+      add: function () {},
     },
 
-    tokenize: function(text, grammar, language) {
+    tokenize: function (text, grammar, language) {
       var strarr = [text];
 
       var rest = grammar.rest;
@@ -357,10 +357,10 @@ var Prism = (function() {
       _.matchGrammar(text, strarr, grammar, 0, 0, false);
 
       return strarr;
-    }
+    },
   };
 
-  var Token = (_.Token = function(type, content, alias, matchedStr, greedy) {
+  var Token = (_.Token = function (type, content, alias, matchedStr, greedy) {
     this.type = type;
     this.content = content;
     this.alias = alias;
@@ -369,14 +369,14 @@ var Prism = (function() {
     this.greedy = !!greedy;
   });
 
-  Token.stringify = function(o, language, parent) {
+  Token.stringify = function (o, language, parent) {
     if (typeof o == "string") {
       return o;
     }
 
     if (_.util.type(o) === "Array") {
       return o
-        .map(function(element) {
+        .map(function (element) {
           return Token.stringify(element, language, o);
         })
         .join("");
@@ -389,7 +389,7 @@ var Prism = (function() {
       classes: ["token", o.type],
       attributes: {},
       language: language,
-      parent: parent
+      parent: parent,
     };
 
     if (o.alias) {
@@ -398,7 +398,7 @@ var Prism = (function() {
     }
 
     var attributes = Object.keys(env.attributes)
-      .map(function(name) {
+      .map(function (name) {
         return (
           name +
           '="' +


### PR DESCRIPTION
Follow up on https://github.com/FormidableLabs/prism-react-renderer/pull/106

I noticed that not all `js` files under `src` were linted. The `format` script was using `src/**/*.js` glob, but per https://github.com/prettier/prettier/issues/2078#issuecomment-307539076 it should be enclosed in single quotes to function properly. Otherwise, it would only look for `js` files in a first-level directory such as `src/components/Highlight.js` and not `src/vendor/prism/prism-core.js` nor `src/types.js`