### PR TITLE
Fix/types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,8 +45,7 @@ declare module "prism-react-renderer" {
     languages: LanguageDict;
     tokenize: (
       code: string,
-      grammar: PrismGrammar,
-      language: Language
+      grammar: PrismGrammar
     ) => PrismToken[] | string[];
     highlight: (
       code: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 declare module "prism-react-renderer" {
   import * as React from "react";
+  import type PrismJS from 'prismjs';
 
   type Language =
     | "markup"
@@ -154,7 +155,7 @@ declare module "prism-react-renderer" {
   };
 
   interface HighlightProps {
-    Prism: PrismLib;
+    Prism: PrismLib | PrismJS;
     theme?: PrismTheme;
     language: Language;
     code: string;

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@testing-library/react": "^11.2.5",
+    "@types/prismjs": "^1.26.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^26.6.3",
     "babel-plugin-macros": "^3.0.1",

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -137,11 +137,7 @@ class Highlight extends Component<Props, *> {
     };
 
     Prism.hooks.run("before-tokenize", env);
-    const tokens = (env.tokens = Prism.tokenize(
-      env.code,
-      env.grammar,
-      env.language
-    ));
+    const tokens = (env.tokens = Prism.tokenize(env.code, env.grammar));
     Prism.hooks.run("after-tokenize", env);
 
     return tokens;

--- a/src/types.js
+++ b/src/types.js
@@ -27,11 +27,7 @@ export type Token = {
 
 export type PrismLib = {
   languages: LanguagesDict,
-  tokenize: (
-    code: string,
-    grammar: PrismGrammar,
-    language: Language
-  ) => Array<PrismToken | string>,
+  tokenize: (code: string, grammar: PrismGrammar) => Array<PrismToken | string>,
   highlight: (
     code: string,
     grammar: PrismGrammar,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,6 +1316,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.1.tgz#374e31645d58cb18a07b3ecd8e9dede4deb2cccd"
   integrity sha512-DxZZbyMAM9GWEzXL+BMZROWz9oo6A9EilwwOMET2UVu2uZTqMWS5S69KVtuVKaRjCUpcrOXRalet86/OpG4kqw==
 
+"@types/prismjs@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.0.tgz#a1c3809b0ad61c62cac6d4e0c56d610c910b7654"
+  integrity sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"


### PR DESCRIPTION
Two fixes to our type definitions and a no-op code change

1. `Prism.tokenize` only takes two arguments not three
2. Users can provider their own `PrismJS` module (closes #136)