### PR TITLE
add dart to the syntax language list

### DIFF
--- a/src/vendor/prism/includeLangs.js
+++ b/src/vendor/prism/includeLangs.js
@@ -11,6 +11,7 @@ module.exports = {
   cpp: true,
   css: true,
   "css-extras": true,
+  dart: true,
   javascript: true,
   jsx: true,
   "js-extras": true,


### PR DESCRIPTION
With the new flutter agent release, I need to add dart to the syntax language list.