### PR TITLE
Bump to Prism 1.29, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,141 +68,60 @@ should be installed as one of your project's `dependencies`:
 npm install --save prism-react-renderer
 # yarn
 yarn add prism-react-renderer
+# pnpm
+pnpm add prism-react-renderer
 ```
 
-> This package also depends on `react`. Please make sure you
-> have those installed as well.
+> Prism React Renderer has a peer dependency on `react`
 
-## Usage
+### How to use Prism React Renderer
+Prism React Renderer has a named export for the `<Highlight />` component along with `themes`. To see Prism React Render in action with base styling check out `packages/demo` or run `pnpm run start:demo` from the root of this repository.
 
-> [Try it out in the browser](https://codesandbox.io/s/prism-react-renderer-example-u6vhk)
+```tsx
+import React from "react"
+import ReactDOM from "react-dom/client"
+import { Highlight, themes } from "prism-react-renderer"
+import styles from 'styles.module.css'
 
-<img src="./.readme/basic.png" width="237" alt="Screenshot showing highlighted code block" />
+const codeBlock = `
+const GroceryItem: React.FC<GroceryItemProps> = ({ item }) => {
+  return (
+    <div>
+      <h2>{item.name}</h2>
+      <p>Price: {item.price}</p>
+      <p>Quantity: {item.quantity}</p>
+    </div>
+  );
+}
+`
 
-```jsx
-import React from "react";
-import { render } from "react-dom";
-// import { createRoot } from "react-dom/client";
-import Highlight, { defaultProps } from "prism-react-renderer";
-
-const exampleCode = `
-(function someDemo() {
-  var test = "Hello World!";
-  console.log(test);
-})();
-
-return () => <App />;
-`;
-
-const Content = (
-  <Highlight {...defaultProps} code={exampleCode} language="jsx">
+export const App = () => (
+  <Highlight
+    theme={themes.shadesOfPurple}
+    code={codeBlock}
+    language="tsx"
+  >
     {({ className, style, tokens, getLineProps, getTokenProps }) => (
-      <pre className={className} style={style}>
+      <pre style={style}>
         {tokens.map((line, i) => (
-          <div {...getLineProps({ line, key: i })}>
+          <div key={i} {...getLineProps({ line })}>
+            <span>{i + 1}</span>
             {line.map((token, key) => (
-              <span {...getTokenProps({ token, key })} />
+              <span key={key} {...getTokenProps({ token })} />
             ))}
           </div>
         ))}
       </pre>
     )}
   </Highlight>
-);
-render(Content, document.getElementById('root'));
+)
 
-// If you are using React 18
-// const root = createRoot(document.getElementById('root'));
-// root.render(Content);
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
+        .render(<App />)
+
 ```
 
-`<Highlight />` is the only component exposed by this package, as inspired by
-[downshift](https://github.com/paypal/downshift).
 
-It also exports a `defaultProps` object which for basic usage can simply be spread
-onto the `<Highlight />` component. It also provides some default theming.
-
-It doesn't render anything itself, it just calls the render function and renders that.
-["Use a render prop!"](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce)!
-`<Highlight>{highlight => <pre>/* your JSX here! */</pre>}</Highlight>`
-
-### Line Numbers
-
-Add line numbers to your highlighted code blocks using the `index` parameter in your `line.map` function:
-
-<img src="./.readme/line-numbers.png" width="453" alt="Screenshot showing line numbers in highlighted code block" />
-
-For example, if you were using `styled-components`, it could look like the following demo.
-
-> [Demo with `styled-components`](https://codesandbox.io/s/prism-react-renderer-example-u6vhk?file=/src/WithLineNumbers.js)
-
-```js
-import React from "react";
-import styled from "styled-components";
-import Highlight, { defaultProps } from "prism-react-renderer";
-import theme from "prism-react-renderer/themes/nightOwl";
-
-const exampleCode = `
-import React, { useState } from "react";
-
-function Example() {
-  const [count, setCount] = useState(0);
-
-  return (
-    <div>
-      <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
-        Click me
-      </button>
-    </div>
-  );
-}
-`.trim();
-
-const Pre = styled.pre`
-  text-align: left;
-  margin: 1em 0;
-  padding: 0.5em;
-  overflow: scroll;
-`;
-
-const Line = styled.div`
-  display: table-row;
-`;
-
-const LineNo = styled.span`
-  display: table-cell;
-  text-align: right;
-  padding-right: 1em;
-  user-select: none;
-  opacity: 0.5;
-`;
-
-const LineContent = styled.span`
-  display: table-cell;
-`;
-
-const WithLineNumbers = () => (
-  <Highlight {...defaultProps} theme={theme} code={exampleCode} language="jsx">
-    {({ className, style, tokens, getLineProps, getTokenProps }) => (
-      <Pre className={className} style={style}>
-        {tokens.map((line, i) => (
-          <Line key={i} {...getLineProps({ line, key: i })}>
-            <LineNo>{i + 1}</LineNo>
-            <LineContent>
-              {line.map((token, key) => (
-                <span key={key} {...getTokenProps({ token, key })} />
-              ))}
-            </LineContent>
-          </Line>
-        ))}
-      </Pre>
-    )}
-  </Highlight>
-);
-
-export default WithLineNumbers;
-```
 
 ## Basic Props
 
@@ -235,19 +154,17 @@ This is the code that will be highlighted.
 
 ### theme
 
-> `PrismTheme` | _required; default is provided in `defaultProps` export_
+> `PrismTheme` | _optional; default is vsDark_
 
 If a theme is passed, it is used to generate style props which can be retrieved
 via the prop-getters which are described in "[Children Function](#children-function)".
 
-A default theme is provided by the `defaultProps` object.
-
 Read more about how to theme `prism-react-renderer` in
 the section "[Theming](#theming)".
 
-### Prism
+### prism
 
-> `PrismLib` | _required; default is provided in `defaultProps` export_
+> `prism` | _optional; default is the vendored version_
 
 This is the [Prismjs](https://github.com/PrismJS/prism) library itself.
 A vendored version of Prism is provided (and also exported) as part of this library.
@@ -263,7 +180,7 @@ But if you choose to use your own Prism setup, simply pass Prism as a prop:
 // Whichever way you're retrieving Prism here:
 import Prism from 'prismjs/components/prism-core';
 
-<Highlight Prism={Prism} {/* ... */} />
+<Highlight prism={prism} {/* ... */} />
 ```
 
 ## Children Function
@@ -349,15 +266,15 @@ your old Prism CSS-file themes.
 ## Theming
 
 The `defaultProps` you'd typically apply in a basic use-case, contain a default theme.
-This theme is [duotoneDark](./src/themes/duotoneDark.js).
+This theme is [vsDark](./packages/prism-react-renderer/src/themes/vsDark.ts).
 
 While all `className`s are provided with `<Highlight />`, so that you could use your good
 old Prism CSS-file themes, you can also choose to use `prism-react-renderer`'s themes like so:
 
 ```jsx
-import dracula from 'prism-react-renderer/themes/dracula';
+import { Highlight, themes } from 'prism-react-renderer';
 
-<Highlight theme={dracula} {/* ... */} />
+<Highlight theme={themes.dracula} {/* ... */} />
 ```
 
 These themes are JSON-based and are heavily inspired by VSCode's theme format.

--- a/package.json
+++ b/package.json
@@ -13,11 +13,9 @@
     "build:languages": "pnpm --filter generate-prism-languages build",
     "build:watch": "pnpm --filter generate-prism-languages build && pnpm --filter prism-react-renderer build:watch",
     "changeset": "changeset",
-    "version": "pnpm changeset version && pnpm install"
+    "version": "pnpm changeset version"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.26.0",
-    "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "@babel/cli": "^7.10.4",
     "@babel/core": "^7.21.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
@@ -26,25 +24,31 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.16.0",
+    "@changesets/cli": "^2.26.0",
+    "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "@testing-library/react": "^11.2.5",
     "@types/react": "^18.0.35",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",
+    "babel-jest": "^26.6.3",
+    "babel-plugin-macros": "^3.0.1",
+    "codegen.macro": "^4.1.0",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",
-    "babel-jest": "^26.6.3",
-    "babel-plugin-macros": "^3.0.1",
-    "codegen.macro": "^4.1.0",
     "globby": "^11.0.2",
-    "prismjs": "1.26.0",
-    "patch-package": "^6.4.7",
     "prettier": "^2.8.7",
+    "prismjs": "1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.0.4"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "prismjs@1.29.0": "patches/prismjs@1.29.0.patch"
+    }
   }
 }

--- a/packages/prism-react-renderer/package.json
+++ b/packages/prism-react-renderer/package.json
@@ -13,8 +13,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "patch-package && tsup",
-    "build:watch": "patch-package && tsup --watch",
+    "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",

--- a/patches/prismjs@1.29.0.patch
+++ b/patches/prismjs@1.29.0.patch
@@ -1,15 +1,11 @@
-diff --git a/node_modules/prismjs/prism.js b/node_modules/prismjs/prism.js
-index 7d2bc60..dd4fc04 100644
---- a/node_modules/prismjs/prism.js
-+++ b/node_modules/prismjs/prism.js
-@@ -1,18 +1,3 @@
--
--/* **********************************************
--     Begin prism-core.js
--********************************************** */
--
--/// <reference lib="WebWorker"/>
--
+diff --git a/prism.js b/prism.js
+index 4b9c9a0f8a0356a2dfbf4446bbd4bfe01498ce91..9fd04334b4dc420aeaf82905859616774346a3f7 100644
+--- a/prism.js
++++ b/prism.js
+@@ -5,14 +5,6 @@
+ 
+ /// <reference lib="WebWorker"/>
+ 
 -var _self = (typeof window !== 'undefined')
 -	? window   // if in browser
 -	: (
@@ -21,28 +17,16 @@ index 7d2bc60..dd4fc04 100644
  /**
   * Prism: Lightweight, robust, elegant syntax highlighting
   *
-@@ -21,7 +6,19 @@ var _self = (typeof window !== 'undefined')
+@@ -21,7 +13,7 @@ var _self = (typeof window !== 'undefined')
   * @namespace
   * @public
   */
 -var Prism = (function (_self) {
-+
-+/**
-+ * prism-react-renderer:
-+ * This file has been modified to remove:
-+ * - globals and window dependency
-+ * - worker support
-+ * - highlightAll and other element dependent methods
-+ * - _.hooks helpers
-+ * - UMD/node-specific hacks
-+ * It has also been run through prettier
-+ */
-+
-+ var Prism = (function () {
++var Prism = (function () {
  
  	// Private helper vars
  	var lang = /(?:^|\s)lang(?:uage)?-([\w-]+)(?=\s|$)/i;
-@@ -32,51 +29,6 @@ var Prism = (function (_self) {
+@@ -32,51 +24,6 @@ var Prism = (function (_self) {
  
  
  	var _ = {
@@ -94,7 +78,7 @@ index 7d2bc60..dd4fc04 100644
  		/**
  		 * A namespace for utility methods.
  		 *
-@@ -216,48 +168,6 @@ var Prism = (function (_self) {
+@@ -216,48 +163,6 @@ var Prism = (function (_self) {
  				element.classList.add('language-' + language);
  			},
  
@@ -143,7 +127,7 @@ index 7d2bc60..dd4fc04 100644
  			/**
  			 * Returns whether a given class is active for `element`.
  			 *
-@@ -487,155 +397,6 @@ var Prism = (function (_self) {
+@@ -487,156 +392,6 @@ var Prism = (function (_self) {
  
  		plugins: {},
  
@@ -296,21 +280,24 @@ index 7d2bc60..dd4fc04 100644
 -				insertHighlightedCode(_.highlight(env.code, env.grammar, env.language));
 -			}
 -		},
- 		
+-
  		/**
  		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input
-@@ -763,7 +524,6 @@ var Prism = (function (_self) {
+ 		 * and the language definitions to use, and returns a string with the HTML produced.
+@@ -766,8 +521,6 @@ var Prism = (function (_self) {
  
  		Token: Token
  	};
 -	_self.Prism = _;
- 
+-
  
  	// Typescript note:
-@@ -1141,784 +901,9 @@ var Prism = (function (_self) {
+ 	// The following can be used to import the Token type in JSDoc:
+@@ -1143,804 +896,8 @@ var Prism = (function (_self) {
+ 		}
  		return array;
  	}
- 
+-
 -
 -	if (!_self.document) {
 -		if (!_self.addEventListener) {
@@ -373,7 +360,7 @@ index 7d2bc60..dd4fc04 100644
 -	}
 -
  	return _;
- 
+-
 -}(_self));
 -
 -if (typeof module !== 'undefined' && module.exports) {
@@ -492,7 +479,10 @@ index 7d2bc60..dd4fc04 100644
 -							pattern: /^=/,
 -							alias: 'attr-equals'
 -						},
--						/"|'/
+-						{
+-							pattern: /^(\s*)["']|["']$/,
+-							lookbehind: true
+-						}
 -					]
 -				}
 -			},
@@ -635,7 +625,7 @@ index 7d2bc60..dd4fc04 100644
 -	Prism.languages.css = {
 -		'comment': /\/\*[\s\S]*?\*\//,
 -		'atrule': {
--			pattern: /@[\w-](?:[^;{\s]|\s+(?![\s{]))*(?:;|(?=\s*\{))/,
+-			pattern: RegExp('@[\\w-](?:' + /[^;{\s"']|\s+(?!\s)/.source + '|' + string.source + ')*?' + /(?:;|(?=\s*\{))/.source),
 -			inside: {
 -				'rule': /^@[\w-]+/,
 -				'selector-function-argument': {
@@ -790,8 +780,24 @@ index 7d2bc60..dd4fc04 100644
 -
 -Prism.languages.insertBefore('javascript', 'keyword', {
 -	'regex': {
--		// eslint-disable-next-line regexp/no-dupe-characters-character-class
--		pattern: /((?:^|[^$\w\xA0-\uFFFF."'\])\s]|\b(?:return|yield))\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*\]|\\.|[^/\\\[\r\n])+\/[dgimyus]{0,7}(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+-		pattern: RegExp(
+-			// lookbehind
+-			// eslint-disable-next-line regexp/no-dupe-characters-character-class
+-			/((?:^|[^$\w\xA0-\uFFFF."'\])\s]|\b(?:return|yield))\s*)/.source +
+-			// Regex pattern:
+-			// There are 2 regex patterns here. The RegExp set notation proposal added support for nested character
+-			// classes if the `v` flag is present. Unfortunately, nested CCs are both context-free and incompatible
+-			// with the only syntax, so we have to define 2 different regex patterns.
+-			/\//.source +
+-			'(?:' +
+-			/(?:\[(?:[^\]\\\r\n]|\\.)*\]|\\.|[^/\\\[\r\n])+\/[dgimyus]{0,7}/.source +
+-			'|' +
+-			// `v` flag syntax. This supports 3 levels of nested character classes.
+-			/(?:\[(?:[^[\]\\\r\n]|\\.|\[(?:[^[\]\\\r\n]|\\.|\[(?:[^[\]\\\r\n]|\\.)*\])*\])*\]|\\.|[^/\\\[\r\n])+\/[dgimyus]{0,7}v[dgimyus]{0,7}/.source +
+-			')' +
+-			// lookahead
+-			/(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/.source
+-		),
 -		lookbehind: true,
 -		greedy: true,
 -		inside: {
@@ -1093,5 +1099,5 @@ index 7d2bc60..dd4fc04 100644
 -
  }());
 +
-+module.exports = Prism
-+Prism.default = Prism
++module.exports = Prism;
++Prism.default = Prism;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: '6.0'
 
+patchedDependencies:
+  prismjs@1.29.0:
+    hash: vrxx3pzkik6jpmgpayxfjunetu
+    path: patches/prismjs@1.29.0.patch
+
 importers:
 
   .:
@@ -76,15 +81,12 @@ importers:
       globby:
         specifier: ^11.0.2
         version: 11.1.0
-      patch-package:
-        specifier: ^6.4.7
-        version: 6.5.1
       prettier:
         specifier: ^2.8.7
         version: 2.8.7
       prismjs:
-        specifier: 1.26.0
-        version: 1.26.0
+        specifier: 1.29.0
+        version: 1.29.0(patch_hash=vrxx3pzkik6jpmgpayxfjunetu)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -155,7 +157,7 @@ importers:
         version: 1.0.0
       prismjs:
         specifier: '*'
-        version: 1.26.0
+        version: 1.29.0(patch_hash=vrxx3pzkik6jpmgpayxfjunetu)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@18.15.11)(typescript@5.0.4)
@@ -219,7 +221,7 @@ importers:
         version: 9.7.1
       prismjs:
         specifier: '*'
-        version: 1.26.0
+        version: 1.29.0(patch_hash=vrxx3pzkik6jpmgpayxfjunetu)
       react:
         specifier: '*'
         version: 18.2.0
@@ -2824,10 +2826,6 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@yarnpkg/lockfile@1.1.0:
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
-    dev: true
-
   /acorn-dynamic-import@4.0.0(acorn@6.4.2):
     resolution: {integrity: sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==}
     deprecated: This is probably built in to whatever tool you're using. If you still need it... idk
@@ -3042,11 +3040,6 @@ packages:
   /assign-symbols@1.0.0:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
     dev: true
 
   /atob@2.1.2:
@@ -4323,12 +4316,6 @@ packages:
       pkg-dir: 4.2.0
     dev: true
 
-  /find-yarn-workspace-root@2.0.0:
-    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
-    dependencies:
-      micromatch: 4.0.5
-    dev: true
-
   /flat-cache@3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4386,16 +4373,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: true
-
-  /fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      at-least-node: 1.0.0
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
     dev: true
 
   /fs-readdir-recursive@1.1.0:
@@ -4854,12 +4831,6 @@ packages:
       kind-of: 6.0.3
     dev: true
 
-  /is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dev: true
-
   /is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -5028,13 +4999,6 @@ packages:
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
     dev: true
 
   /isarray@1.0.0:
@@ -5259,14 +5223,6 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
-  /jsonfile@6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
-    dependencies:
-      universalify: 2.0.0
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    dev: true
-
   /jsx-ast-utils@3.3.3:
     resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
     engines: {node: '>=4.0'}
@@ -5297,12 +5253,6 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /klaw-sync@6.0.0:
-    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
-    dependencies:
-      graceful-fs: 4.2.11
     dev: true
 
   /kleur@4.1.5:
@@ -5805,14 +5755,6 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
-    dev: true
-
   /optionator@0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
     engines: {node: '>= 0.8.0'}
@@ -5911,27 +5853,6 @@ packages:
   /pascalcase@0.1.1:
     resolution: {integrity: sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /patch-package@6.5.1:
-    resolution: {integrity: sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==}
-    engines: {node: '>=10', npm: '>5'}
-    hasBin: true
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      chalk: 4.1.2
-      cross-spawn: 6.0.5
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 9.1.0
-      is-ci: 2.0.0
-      klaw-sync: 6.0.0
-      minimist: 1.2.8
-      open: 7.4.2
-      rimraf: 2.7.1
-      semver: 5.7.1
-      slash: 2.0.0
-      tmp: 0.0.33
-      yaml: 1.10.2
     dev: true
 
   /path-exists@4.0.0:
@@ -6092,10 +6013,11 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /prismjs@1.26.0:
-    resolution: {integrity: sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==}
+  /prismjs@1.29.0(patch_hash=vrxx3pzkik6jpmgpayxfjunetu):
+    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
     dev: true
+    patched: true
 
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -6362,13 +6284,6 @@ packages:
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
-
-  /rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
     dev: true
 
   /rimraf@3.0.2:
@@ -7170,11 +7085,6 @@ packages:
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
-    dev: true
-
-  /universalify@2.0.0:
-    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
-    engines: {node: '>= 10.0.0'}
     dev: true
 
   /unset-value@1.0.0:


### PR DESCRIPTION
- Moves our vendor-provided version of Prism to `1.29.0` and removes `patch-package` for pnpm's own patching.
- Updates the README for the new API changes

Please kick the tires and run the demo/build to make sure this all works on clean machines.