### PR TITLE
Fix dependent types for PrismJS

### DIFF
--- a/.changeset/cold-cows-joke.md
+++ b/.changeset/cold-cows-joke.md
@@ -1,0 +1,5 @@
+---
+"prism-react-renderer": patch
+---
+
+Fix inclusion of @types dependency for prismjs

--- a/packages/generate-prism-languages/index.ts
+++ b/packages/generate-prism-languages/index.ts
@@ -28,7 +28,7 @@ export const languagesToBundle = <const>[
  * that starts off assuming Prism lives in global scope. We also need to provide Prism as that
  * gets passed into an iffe preventing us from needing to use global scope.
  */
-const header = `// eslint-disable-next-line @typescript-eslint/ban-ts-comment\n// @ts-nocheck\nimport Prism from "prismjs";\nexport { Prism };`
+const header = `// eslint-disable-next-line @typescript-eslint/ban-ts-comment\n// @ts-nocheck\nimport * as Prism from "prismjs";\nexport { Prism };`
 const prismPath = dirname(require.resolve("prismjs"))
 
 const readLanguageFile = async (language: string): Promise<string> => {

--- a/packages/prism-react-renderer/package.json
+++ b/packages/prism-react-renderer/package.json
@@ -34,7 +34,6 @@
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
-    "@types/prismjs": "^1.26.0",
     "@vitejs/plugin-react": "^3.1.0",
     "babel-plugin-codegen": "^4.1.5",
     "happy-dom": "^9.7.1",
@@ -50,6 +49,7 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
+    "@types/prismjs": "^1.26.0",
     "clsx": "^1.2.1"
   }
 }

--- a/packages/prism-react-renderer/src/types.ts
+++ b/packages/prism-react-renderer/src/types.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react"
-import { Token as PrismToken } from "prismjs"
+import type { Token as PrismToken } from "prismjs"
 
 export type Language = string
 export type PrismGrammar = Record<string, unknown>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
 
   packages/prism-react-renderer:
     dependencies:
+      '@types/prismjs':
+        specifier: ^1.26.0
+        version: 1.26.0
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -213,9 +216,6 @@ importers:
       '@types/node':
         specifier: ^18.15.11
         version: 18.15.11
-      '@types/prismjs':
-        specifier: ^1.26.0
-        version: 1.26.0
       '@vitejs/plugin-react':
         specifier: ^3.1.0
         version: 3.1.0(vite@4.2.1)
@@ -2583,7 +2583,6 @@ packages:
 
   /@types/prismjs@1.26.0:
     resolution: {integrity: sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==}
-    dev: true
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}


### PR DESCRIPTION
Ensure `@types/prismjs` is a dependency for prism-react-renderer.

Addresses #195 