### PR TITLE
Package readme

### DIFF
--- a/.changeset/unlucky-crews-act.md
+++ b/.changeset/unlucky-crews-act.md
@@ -1,0 +1,5 @@
+---
+"prism-react-renderer": patch
+---
+
+Add package README

--- a/packages/prism-react-renderer/.gitignore
+++ b/packages/prism-react-renderer/.gitignore
@@ -1,0 +1,1 @@
+README.md

--- a/packages/prism-react-renderer/package.json
+++ b/packages/prism-react-renderer/package.json
@@ -18,7 +18,8 @@
     "test": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
-    "format": "prettier --write 'src/**/*.js'"
+    "format": "prettier --write 'src/**/*.js'",
+    "prepublishOnly": "cp ../../README.md ./README.md"
   },
   "peerDependencies": {
     "react": ">=16.0.0"


### PR DESCRIPTION
On prepublish, copy root README into package directory so it gets published to NPM.