### PR TITLE
Fix types for `prism` library prop.

### DIFF
--- a/.changeset/popular-seals-occur.md
+++ b/.changeset/popular-seals-occur.md
@@ -1,0 +1,5 @@
+---
+"prism-react-renderer": patch
+---
+
+Fix types for Prism library.

--- a/packages/prism-react-renderer/src/types.ts
+++ b/packages/prism-react-renderer/src/types.ts
@@ -1,25 +1,10 @@
 import type { CSSProperties } from "react"
-import type { Token as PrismToken } from "prismjs"
+import type { Token as PrismToken, Grammar } from "prismjs"
+import Prism from "prismjs"
 
 export type Language = string
-export type PrismGrammar = Record<string, unknown>
-type LanguagesDict = Record<Language, PrismGrammar>
-
-export type PrismLib = {
-  languages: LanguagesDict
-  tokenize: (code: string, grammar: PrismGrammar) => Array<PrismToken | string>
-  highlight: (code: string, grammar: PrismGrammar, language: Language) => string
-  hooks: {
-    run: (
-      name: string,
-      env: {
-        code: string
-        grammar: PrismGrammar
-        language: Language
-      }
-    ) => void
-  }
-}
+export type PrismGrammar = Grammar
+export type PrismLib = typeof Prism
 
 export type Token = {
   types: string[]


### PR DESCRIPTION
Previously we had custom definitions—this is no longer needed with using the latest published version of Prism.

Addresses #203 


👇🏻 Now with using the library types, there are no ts errors

<img width="409" alt="Screenshot 2023-05-07 at 3 10 03 PM" src="https://user-images.githubusercontent.com/1738349/236700533-e8a29f59-76ff-431f-9df0-be0fdac3212c.png">
