### PR TITLE
Fixed undefined themes causing a runtime error.

### DIFF
--- a/.changeset/old-chicken-turn.md
+++ b/.changeset/old-chicken-turn.md
@@ -1,0 +1,5 @@
+---
+"prism-react-renderer": patch
+---
+
+Fixed bug where an undefined theme would cause a runtime error.

--- a/packages/prism-react-renderer/src/index.ts
+++ b/packages/prism-react-renderer/src/index.ts
@@ -10,8 +10,10 @@ import { HighlightProps, PrismLib } from "./types"
  */
 const Highlight = (props: HighlightProps) =>
   createElement(InternalHighlight, {
-    prism: Prism as PrismLib,
-    theme: themes.vsDark,
     ...props,
+    prism: props.prism || (Prism as PrismLib),
+    theme: props.theme || themes.vsDark,
+    code: props.code,
+    language: props.language,
   })
 export { Highlight, Prism, themes }


### PR DESCRIPTION
Addresses #212 

The spread order of the internal highlight component was overriding the theme provided by props. This fixes the bug where not providing a theme (and falling back to the internal one) will work correctly.

How to test:

- Build the library and run the /demo project
- Remove `active` prop theme from `<Highlight />` _or_ pass in `undefined`
- See that it still works