### PR TITLE
Export all types from package

### DIFF
--- a/.changeset/fair-spies-itch.md
+++ b/.changeset/fair-spies-itch.md
@@ -1,0 +1,5 @@
+---
+"prism-react-renderer": patch
+---
+
+Export all types from package

--- a/packages/prism-react-renderer/src/index.ts
+++ b/packages/prism-react-renderer/src/index.ts
@@ -3,6 +3,7 @@ import * as themes from "./themes"
 import { createElement } from "react"
 import { Highlight as InternalHighlight } from "./components/highlight"
 import { HighlightProps, PrismLib } from "./types"
+export * from "./types"
 
 /**
  * Prism React Renderer requires this specific instance


### PR DESCRIPTION
Export all types from `./types`. Prism React Renderer has a lot of utility types that can be useful to the consumer and they were previously exported in 1.x.

<img width="518" alt="Screenshot 2023-06-17 at 11 41 12 AM" src="https://github.com/FormidableLabs/prism-react-renderer/assets/1738349/d8642e91-d511-4e95-9b43-0d5b6ad82330">

Addresses #211 