### PR TITLE
Fix HTML preset not highlighting script tags

### DIFF
--- a/.changeset/dry-icons-repeat.md
+++ b/.changeset/dry-icons-repeat.md
@@ -1,0 +1,5 @@
+---
+"prism-react-renderer": patch
+---
+
+Fix html language preset by using markup instead.

--- a/packages/demo/src/sample-code.ts
+++ b/packages/demo/src/sample-code.ts
@@ -56,16 +56,16 @@ const GroceryItem = new Proxy({}, {
 @property (nonatomic, assign) float price;
 @property (nonatomic, assign) NSInteger quantity;
 
-- (instancetype) initWithName: (NSString *)name 
-                        price: (float)price 
+- (instancetype) initWithName: (NSString *)name
+                        price: (float)price
                      quantity: (NSInteger)quantity;
 
 @end
 
 @implementation GroceryItem
 
-- (instancetype) initWithName: (NSString *)name 
-                        price: (float)price 
+- (instancetype) initWithName: (NSString *)name
+                        price: (float)price
                      quantity: (NSInteger)quantity {
     self = [super init];
     if (self) {
@@ -88,6 +88,10 @@ const GroceryItem = new Proxy({}, {
   <head>
     <meta charset="UTF-8" />
     <title>Formidable</title>
+    <script>
+      const name = "Formidable";
+      console.log(name);
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/generate-prism-languages/index.ts
+++ b/packages/generate-prism-languages/index.ts
@@ -7,6 +7,7 @@ import { languages as prismLanguages } from "prismjs/components"
 import uglify from "uglify-js"
 
 export const languagesToBundle = <const>[
+  "markup",
   "jsx",
   "tsx",
   "swift",
@@ -20,7 +21,6 @@ export const languagesToBundle = <const>[
   "go",
   "cpp",
   "markdown",
-  "html",
   "python",
 ]
 


### PR DESCRIPTION
- Swaps out the `html` preset  for `markdown` which does not code highlight the javascript inside a `<script />` tag
- Addresses https://github.com/facebook/docusaurus/issues/9517#issuecomment-1806142190
- Updated demo app to handle this case


Example of JavaScript inside a script tag now being highlighted inside a HTML file: 
<img width="1063" alt="Screenshot 2023-11-10 at 4 55 26 PM" src="https://github.com/FormidableLabs/prism-react-renderer/assets/1738349/b2cb3e77-4be2-4996-93a9-917dfeedbd8f">
