### PR TITLE
React 19 docs - do not advise to add a key in `getLineProps` + `getTokenProps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ advisable.
 #### `getLineProps`
 
 You need to add a `line` property (type: `Token[]`) to the object you're passing to
-`getLineProps`; It's also advisable to add a `key`.
+`getLineProps`.
 
 This getter will return you props to spread onto your line elements (typically `<div>s`).
 
@@ -277,7 +277,7 @@ The `className` will always contain `.token-line`.
 #### `getTokenProps`
 
 You need to add a `token` property (type: `Token`) to the object you're passing to
-`getTokenProps`; It's also advisable to add a `key`.
+`getTokenProps`.
 
 This getter will return you props to spread onto your token elements (typically `<span>s`).
 


### PR DESCRIPTION
Starting React 18.3, this kind of code:

```jsx
const lineTokens = line.map((token, key) => (
  <span key={key} {...getTokenProps({token, key})} />
));
```

leads to the following warning:

```
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, className: ..., children: ..., style: ...};
  <span {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {className: ..., children: ..., style: ...};
  <span key={someKey} {...props} />
    at CodeBlockLine (webpack-internal:///../packages/docusaurus-theme-classic/lib/theme/CodeBlock/Line/index.js:10:26)
```

I think the doc is a bit confusing (it led us to historically write the code above, although it's not what you show in the examples) while the key should rather be kept outside the PRR API calls, not spreading it. 

This should be enough:

```jsx
const lineTokens = line.map((token, key) => (
  <span key={key} {...getTokenProps({token})} />
));
```

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

### How Has This Been Tested?

Docusaurus fixing React v18.3 warnings: https://github.com/facebook/docusaurus/pull/10079

